### PR TITLE
Add support for `gems.rb`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,9 @@ class PackageRubyBundlePlugin {
     this.serverless.service.package.exclude = ["**"]; // force whitelist
     this.serverless.service.package.include.push("vendor/bundle/bundler/**"); // bundler standalone files
 
-    const gemFilePath = path.join(this.serverless.config.servicePath, "Gemfile");
+    const gemFilePath = ['Gemfile', 'gems.rb']
+      .map(filename => path.join(this.serverless.config.servicePath, filename))
+      .find(fullpath => fs.existsSync(fullpath))
     const bundleEnv = Object.assign({
       "BUNDLE_GEMFILE": gemFilePath
     }, process.env);

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -1,9 +1,42 @@
-pushd __tests__/demo_service
-echo '### BUILD PACKAGE'
-serverless package
-echo
-echo '### 1) EXAMINE PACKAGE'
-unzip -l .serverless/demo.zip
-echo
-echo '### 2) VERIFY FUNCTION CAN LOAD DEPENDENCIES'
-serverless invoke local -f hello
+setup_gemfile() {
+  if test "$1" = 'gems.rb'; then
+    echo "### RENAME Gemfile TO gems.rb"
+    mv Gemfile gems.rb
+    mv Gemfile.lock gems.locked
+  fi
+}
+
+restore_default_gemfile() {
+  if test "$1" = 'gems.rb'; then
+    echo "### RENAME gems.rb TO Gemfile"
+    mv gems.rb Gemfile
+    mv gems.locked Gemfile.lock
+  fi
+}
+
+run_test() {
+  GEMFILE=$1
+
+  echo "### BUILD DEMO_SERVICE WITH $GEMFILE"
+  pushd __tests__/demo_service
+
+  setup_gemfile $GEMFILE
+
+  echo '### BUILD PACKAGE'
+  serverless package
+  echo
+
+  echo '### 1) EXAMINE PACKAGE'
+  unzip -l .serverless/demo.zip
+  echo
+
+  echo '### 2) VERIFY FUNCTION CAN LOAD DEPENDENCIES'
+  serverless invoke local -f hello
+
+  restore_default_gemfile $GEMFILE
+
+  popd
+}
+
+run_test Gemfile
+run_test gems.rb


### PR DESCRIPTION
We use `gems.rb` (and `gems.locked`) and as a workaround, passing the `BUNDLER_GEMFILE` environment variable to the `serverless` call works for us. However, things would be more of a no-brainer, if `serverless-ruby-package` could determine the right file by itself.

This PR addresses exactly that issue.