### PR TITLE
Custom image

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ class PackageRubyBundlePlugin {
       },
       (
         this.serverless.service.custom &&
-        this.serverless.service.custom.rubyPackage
+        this.serverless.service.custom.rubyPackage,
+        this.serverless.service.custom.dockerImage
       ) || {}
     );
     // give precedence to environment variable, if set

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ class PackageRubyBundlePlugin {
     const config = Object.assign(
       {
         alwaysCrossCompileExtensions: true,
+        dockerImage: 'lambci/lambda:build-ruby2.5',
         debug: !!process.env.SRP_DEBUG,
       },
       (
@@ -105,7 +106,8 @@ class PackageRubyBundlePlugin {
   nativeLinuxBundle(){
     this.log(`Building gems with native extensions for linux`);
     const localPath = this.serverless.config.servicePath;
-    execSync(`docker run --rm -v "${localPath}:/var/task" lambci/lambda:build-ruby2.5 bundle install --standalone --path vendor/bundle`)
+    const dockerImage = this.config.dockerImage;
+    execSync(`docker run --rm -v "${localPath}:/var/task" ${dockerImage} bundle install --standalone --path vendor/bundle`)
   }
 
   warnOnUnsupportedRuntime(){

--- a/index.js
+++ b/index.js
@@ -14,9 +14,7 @@ class PackageRubyBundlePlugin {
       },
       (
         this.serverless.service.custom &&
-        this.serverless.service.custom.rubyPackage,
-        this.serverless.service.custom &&
-        this.serverless.service.custom.dockerImage
+        this.serverless.service.custom.rubyPackage
       ) || {}
     );
     // give precedence to environment variable, if set

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ class PackageRubyBundlePlugin {
       (
         this.serverless.service.custom &&
         this.serverless.service.custom.rubyPackage,
+        this.serverless.service.custom &&
         this.serverless.service.custom.dockerImage
       ) || {}
     );


### PR DESCRIPTION
Now test are ok

yarn run v1.22.4
$ jest
 PASS  __tests__/index.test.js
  ✓ captures the serverless configuration (2ms)
  ✓ captures the options
  ✓ hooks in before packaging deployment artifacts (1ms)
  ✓ hooks in before packaging an individual function
  ✓ disables 'Excluding development dependencies', which only applies to node projects (379ms)
  ✓ forces whitelisting files to package by excluding all files by default (358ms)
  ✓ include the bundler standalone files (349ms)
  ✓ preserve the includes specified in serverless configuration (346ms)
  ✓ include files for each gem needed by default bundler group - excluding .git/test files (346ms)

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        2.582s, estimated 5s
Ran all test suites.
✨  Done in 5.37s.