### PR TITLE
Run integration specs on Mac M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To work on this plugin, you should first run the following in your local directo
 
 yarn test               # run the automated test suite
 
-./integration_test.sh   # run serverless package on the demo project and observe the results
+./integration-test.sh   # run serverless package on the demo project and observe the results
 ```
 
 ### Troubleshooting the demo_service

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -15,6 +15,7 @@ function test_version() {
   echo "## VERIFY RUBY ${version} FUNCTION CAN LOAD DEPENDENCIES"
   #RUBY_IMAGE="amazon/aws-lambda-ruby:3.2" ./invoke-service.sh
   result=$(docker run --rm \
+             --platform linux/amd64 \
              --volume $(pwd):/var/task \
              --env RUBYLIB=/var/task \
              --entrypoint '/var/lang/bin/ruby' \


### PR DESCRIPTION
This addresses an issue I was seeing when attempting to run the integration specs on an M1 Mac:

> The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8)

As well as updating the README to reflect the correct integration test file name